### PR TITLE
feat: add exo-spa-initialize script to activate Apache SSI for specif…

### DIFF
--- a/bin/exo-spa-initialize
+++ b/bin/exo-spa-initialize
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+#
+# Script setup
+#
+
+# Define toolbox directory if not set
+if [[ -z "$TOOLBOX" ]]; then
+    TOOLBOX="$HOME/.exolnet/toolbox"
+fi
+
+# Check if toolbox directory exists
+if [[ ! -d "$TOOLBOX" ]]; then
+    echo "Directory ~/.exolnet does not exists, exiting ..."
+    exit 1
+fi
+
+# Source helpers
+. "$TOOLBOX/lib/include"
+
+#
+# Script checks
+#
+
+# Check if homebrew shell environment variables are defined
+if [[ -z "$HOMEBREW_PREFIX" ]]; then
+    echo
+    echo "Homebrew environment variables are missing."
+    echo "They must be present in your shell profile in order for this script to run."
+    exit 1
+fi
+
+# Check if command was ran as root.
+if [[ $(id -u) -eq 0 ]]; then
+    echo
+    echo "The command \"$(basename "$0")\" should not be executed as root or via sudo directly."
+    echo "When a command requires root access, you will be prompted for a password as needed."
+    exit 1
+fi
+
+# Usage
+if [[ $1 == "--help" ]]; then
+    first=true
+
+    echo -n "Usage: exo-spa-initialize [symlink-name1,symlink-name2,...]"
+    exit 1
+fi
+
+#
+# Script execution
+#
+
+# VirtualHosts
+e_header "Initializing VirtualHosts"
+
+if [[ -z "$2" ]]; then
+    echo
+    slug_default=$(basename "$PWD")
+    ask_question_with_default "Name of the symlink pointing to this project?" "$slug_default"
+    echo
+else
+    REPLY="${@:2}"
+fi
+
+# Split by comma or space and iterate
+IFS=', ' read -ra slugs <<< "$REPLY"
+for slug in "${slugs[@]}"; do
+    # trim spaces
+    slug=$(echo "$slug" | xargs)
+
+    e_arrow "$slug"
+
+    if ! [[ "$slug" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        e_error "Symlink name can only contains alphanumeric characters, underscores and dashes: $slug"
+        exit 1
+    fi
+
+    httpd_create_include_php "$slug"
+    safe_execute "httpd_enable_include_module" "Enable include module in httpd" "Failed to enable include module in httpd"
+    safe_execute "httpd_enable_unique_id_module" "Enable unique_id module in httpd" "Failed to enable unique_id module in httpd"
+    safe_execute "httpd_generate_include_spa $php_version $slug" "Generated apache include file for SPA $slug" "Failed to generated apache include file for SPA $slug"
+done
+sudo_brew_restart httpd
+
+e_header "All done!"

--- a/lib/httpd
+++ b/lib/httpd
@@ -65,6 +65,33 @@ cat >> "$file" <<EOL
 EOL
 }
 
+function httpd_generate_include_spa()
+{
+    local slug=$1
+    local file="$HTTPD_ETC/exolnet-include/$slug.conf"
+
+    remove_spa_insert_from_file "$file"
+
+cat >> "$file" <<EOL
+# EXOLNET-MACOS-TOOLBOX-SPA BEGIN
+<Directory ${HOMEBREW_PREFIX}/var/www/${slug}>
+    Options +IncludesNOEXEC
+    AddOutputFilter INCLUDES .html
+</Directory>
+# EXOLNET-MACOS-TOOLBOX-SPA END
+EOL
+}
+
+function httpd_enable_include_module()
+{
+    /usr/bin/sed -i '' 's/^#\(LoadModule include_module .*\)$/\1/g' "$HTTPD_ETC/httpd.conf"
+}
+
+function httpd_enable_unique_id_module()
+{
+    /usr/bin/sed -i '' 's/^#\(LoadModule unique_id_module .*\)$/\1/g' "$HTTPD_ETC/httpd.conf"
+}
+
 function httpd_enable_mpm_event_module()
 {
     /usr/bin/sed -i '' 's/^#\(LoadModule mpm_event_module .*\)$/\1/g' "$HTTPD_ETC/httpd.conf"

--- a/lib/utils
+++ b/lib/utils
@@ -277,6 +277,14 @@ function remove_insert_from_file2()
     /usr/bin/sed -i '' '/; EXOLNET-MACOS-TOOLBOX BEGIN/,/; EXOLNET-MACOS-TOOLBOX END/d' "$file"
 }
 
+function remove_spa_insert_from_file()
+{
+    local file=$1
+
+    # See: https://nixtricks.wordpress.com/2013/01/09/sed-delete-the-lines-lying-in-between-two-patterns/
+    /usr/bin/sed -i '' '/# EXOLNET-MACOS-TOOLBOX-SPA BEGIN/,/# EXOLNET-MACOS-TOOLBOX-SPA END/d' "$file"
+}
+
 function waiting_for()
 {
     local seconds=$1


### PR DESCRIPTION
This pull request adds support for managing Server Side Includes (SSI) for Single Page Applications (SPA) in the Apache HTTP server configuration scripts. The main changes introduce new utility functions and configuration helpers to enable SSI and related modules, as well as to clean up SPA-specific configuration blocks.

That way we have the ability to add `<!--#echo  encoding=base64 var=UNIQUE_ID -->` that will be replaced by a unique id in html files. Useful for nonce generation for exemple.

**SPA-related configuration management:**
* Added `httpd_generate_include_spa` function in `lib/httpd` to generate Apache `<Directory>` configuration blocks for enabling SSI on SPA directories.
* Added `remove_spa_insert_from_file` function in `lib/utils` to remove SPA-specific SSI configuration blocks from files.

**Apache module enablement:**
* Added `httpd_enable_include_module` function in `lib/httpd` to enable the `include_module` for SSI in Apache by uncommenting its `LoadModule` directive.
* Added `httpd_enable_unique_id_module` function in `lib/httpd` to enable the `unique_id_module` in Apache by uncommenting its `LoadModule` directive.